### PR TITLE
Move to Python 3

### DIFF
--- a/nimrod.py
+++ b/nimrod.py
@@ -51,7 +51,7 @@ Notes:
   3. Tested on UK composite 1km and 5km data, under Linux and Windows XP,
      using Python 2.7
   4. Further details of NIMROD data and software at the NERC BADC website:
-      http://badc.nerc.ac.uk/browse/badc/ukmo-nimrod/   
+      http://badc.nerc.ac.uk/browse/badc/ukmo-nimrod/
 
 Copyright (c) 2015 Richard Thomas
 (Nimrod.__init__() method based on read_nimrod.py by Charles Kilburn Aug 2008)
@@ -65,9 +65,11 @@ but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 """
 
-import sys
-import struct
+import argparse
 import array
+import struct
+import sys
+
 
 class Nimrod:
     """Reading, querying and processing of NIMROD format rainfall data files."""
@@ -76,32 +78,35 @@ class Nimrod:
         """
         Exception Type: NIMROD record length read from file not as expected.
         """
-    
+
         def __init__(self, actual, expected, location):
             self.message = (
                 "Incorrect record length %d bytes (expected %d) at %s."
-                % (actual, expected, location))
+                % (actual, expected, location)
+            )
 
     class HeaderReadError(Exception):
         """Exception Type: Read error whilst parsing NIMROD header elements."""
+
         pass
- 
+
     class PayloadReadError(Exception):
         """Exception Type: Read error whilst parsing NIMROD raster data."""
+
         pass
- 
+
     class BboxRangeError(Exception):
         """
         Exception Type: Bounding box specified out of range of raster image.
         """
+
         pass
- 
- 
+
     def __init__(self, infile):
         """
         Parse all header and data info from a NIMROD data file into this object.
         (This method based on read_nimrod.py by Charles Kilburn Aug 2008)
-                
+
         Args:
             infile: NIMROD file object opened for binary reading
         Raises:
@@ -109,11 +114,11 @@ class Nimrod:
             HeaderReadError: Read error whilst parsing NIMROD header elements
             PayloadReadError: Read error whilst parsing NIMROD raster data
         """
-        
+
         def check_record_len(infile, expected, location):
             """
             Check record length in C struct is as expected.
-            
+
             Args:
                 infile: file to read from
                 expected: expected value of record length read
@@ -122,58 +127,58 @@ class Nimrod:
                 HeaderReadError: Read error whilst reading record length
                 RecordLenError: Unexpected NIMROD record length read from file
             """
-            
+
             # Unpack length from C struct (Big Endian, 4-byte long)
             try:
-                record_length, = struct.unpack(">l", infile.read(4))
+                (record_length,) = struct.unpack(">l", infile.read(4))
             except Exception:
                 raise Nimrod.HeaderReadError
             if record_length != expected:
                 raise Nimrod.RecordLenError(record_length, expected, location)
-        
-        
+
         # Header should always be a fixed length record
         check_record_len(infile, 512, "header start")
-        
+
         try:
             # Read first 31 2-byte integers (header fields 1-31)
             gen_ints = array.array("h")
             gen_ints.fromfile(infile, 31)
             gen_ints.byteswap()
-            
+
             # Read next 28 4-byte floats (header fields 32-59)
             gen_reals = array.array("f")
             gen_reals.fromfile(infile, 28)
             gen_reals.byteswap()
-            
+
             # Read next 45 4-byte floats (header fields 60-104)
             spec_reals = array.array("f")
             spec_reals.fromfile(infile, 45)
             spec_reals.byteswap()
-            
+
             # Read next 56 characters (header fields 105-107)
-            characters = array.array("c")
+            characters = array.array("B")
             characters.fromfile(infile, 56)
-            
+
             # Read next 51 2-byte integers (header fields 108-)
             spec_ints = array.array("h")
             spec_ints.fromfile(infile, 51)
             spec_ints.byteswap()
+
         except Exception:
             infile.close()
             raise Nimrod.HeaderReadError
-    
+
         check_record_len(infile, 512, "header end")
 
         # Extract strings and make duplicate entries to give meaningful names
-        chars = characters.tostring()
+        chars = characters.tobytes()
         self.units = chars[0:8]
         self.data_source = chars[8:32]
         self.title = chars[32:55]
 
         # Store header values in a list so they can be indexed by "element
         # number" shown in NIMROD specification (starts at 1)
-        self.hdr_element = [None]           # Dummy value at element 0
+        self.hdr_element = [None]  # Dummy value at element 0
         self.hdr_element.extend(gen_ints)
         self.hdr_element.extend(gen_reals)
         self.hdr_element.extend(spec_reals)
@@ -181,26 +186,26 @@ class Nimrod:
         self.hdr_element.extend([self.data_source])
         self.hdr_element.extend([self.title])
         self.hdr_element.extend(spec_ints)
-        
+
         # Duplicate some of values to give more meaningful names
         self.nrows = self.hdr_element[16]
         self.ncols = self.hdr_element[17]
         self.n_data_specific_reals = self.hdr_element[22]
         self.n_data_specific_ints = self.hdr_element[23] + 1
-            # Note "+ 1" because header value is count from element 109
+        # Note "+ 1" because header value is count from element 109
         self.y_top = self.hdr_element[34]
         self.y_pixel_size = self.hdr_element[35]
         self.x_left = self.hdr_element[36]
         self.x_pixel_size = self.hdr_element[37]
 
         # Calculate other image bounds (note these are pixel centres)
-        self.x_right = (self.x_left + self.x_pixel_size * (self.ncols - 1))
-        self.y_bottom = (self.y_top - self.y_pixel_size * (self.nrows - 1))
+        self.x_right = self.x_left + self.x_pixel_size * (self.ncols - 1)
+        self.y_bottom = self.y_top - self.y_pixel_size * (self.nrows - 1)
 
         # Read payload (actual raster data)
         array_size = self.ncols * self.nrows
         check_record_len(infile, array_size * 2, "data start")
-             
+
         self.data = array.array("h")
         try:
             self.data.fromfile(infile, array_size)
@@ -212,44 +217,63 @@ class Nimrod:
         check_record_len(infile, array_size * 2, "data end")
         infile.close()
 
-    
     def query(self):
         """Print complete NIMROD file header information."""
-        
-        print "NIMROD file raw header fields listed by element number:"
-        print "General (Integer) header entries:"
+
+        print("NIMROD file raw header fields listed by element number:")
+        print("General (Integer) header entries:")
         for i in range(1, 32):
-            print " ", i, "\t", self.hdr_element[i]
-        print "General (Real) header entries:"
+            print(" ", i, "\t", self.hdr_element[i])
+        print("General (Real) header entries:")
         for i in range(32, 60):
-            print " ", i, "\t", self.hdr_element[i]
-        print ("Data Specific (Real) header entries (%d):"
-               % self.n_data_specific_reals)
+            print(" ", i, "\t", self.hdr_element[i])
+        print(
+            "Data Specific (Real) header entries (%d):"
+            % self.n_data_specific_reals
+        )
         for i in range(60, 60 + self.n_data_specific_reals):
-            print " ", i, "\t", self.hdr_element[i]
-        print ("Data Specific (Integer) header entries (%d):"
-               % self.n_data_specific_ints)
+            print(" ", i, "\t", self.hdr_element[i])
+        print(
+            "Data Specific (Integer) header entries (%d):"
+            % self.n_data_specific_ints
+        )
         for i in range(108, 108 + self.n_data_specific_ints):
-            print " ", i, "\t", self.hdr_element[i]
-        print "Character header entries:"
-        print "  105 Units:           ", self.units
-        print "  106 Data source:     ", self.data_source
-        print "  107 Title of field:  ", self.title    
-            
+            print(" ", i, "\t", self.hdr_element[i])
+        print("Character header entries:")
+        print("  105 Units:           ", self.units)
+        print("  106 Data source:     ", self.data_source)
+        print("  107 Title of field:  ", self.title)
+
         # Print out info & header fields
         # Note that ranges are given to the edge of each pixel
-        print "\nValidity Time:  %2.2d:%2.2d on %2.2d/%2.2d/%4.4d" % (
-            self.hdr_element[4], self.hdr_element[5],
-            self.hdr_element[3], self.hdr_element[2], self.hdr_element[1])
-        print ("Easting range:  %.1f - %.1f (at pixel steps of %.1f)"
-               % (self.x_left - self.x_pixel_size / 2,
-                  self.x_right + self.x_pixel_size / 2, self.x_pixel_size))
-        print ("Northing range: %.1f - %.1f (at pixel steps of %.1f)"
-               % (self.y_bottom - self.y_pixel_size / 2,
-                  self.y_top + self.y_pixel_size / 2, self.y_pixel_size))
-        print "Image size: %d rows x %d cols" % (self.nrows, self.ncols)
+        print(
+            "\nValidity Time:  %2.2d:%2.2d on %2.2d/%2.2d/%4.4d"
+            % (
+                self.hdr_element[4],
+                self.hdr_element[5],
+                self.hdr_element[3],
+                self.hdr_element[2],
+                self.hdr_element[1],
+            )
+        )
+        print(
+            "Easting range:  %.1f - %.1f (at pixel steps of %.1f)"
+            % (
+                self.x_left - self.x_pixel_size / 2,
+                self.x_right + self.x_pixel_size / 2,
+                self.x_pixel_size,
+            )
+        )
+        print(
+            "Northing range: %.1f - %.1f (at pixel steps of %.1f)"
+            % (
+                self.y_bottom - self.y_pixel_size / 2,
+                self.y_top + self.y_pixel_size / 2,
+                self.y_pixel_size,
+            )
+        )
+        print("Image size: %d rows x %d cols" % (self.nrows, self.ncols))
 
-   
     def apply_bbox(self, xmin, xmax, ymin, ymax):
         """
         Clip raster data to all pixels that intersect specified bounding box.
@@ -258,7 +282,7 @@ class Nimrod:
         affected are appropriately adjusted. Because pixels are specified by
         their centre points, a bounding box that comes within half a pixel
         width of the raster edge will intersect with the pixel.
-        
+
         Args:
             xmin: Most negative easting or longitude of bounding box
             xmax: Most positive easting or longitude of bounding box
@@ -267,13 +291,14 @@ class Nimrod:
         Raises:
             BboxRangeError: Bounding box specified out of range of raster image
         """
-        
+
         # Check if there is no overlap of bounding box with raster
         if (
-                xmin > self.x_right  + self.x_pixel_size / 2 or
-                xmax < self.x_left   - self.x_pixel_size / 2 or
-                ymin > self.y_top    + self.y_pixel_size / 2 or
-                ymax < self.y_bottom - self.x_pixel_size / 2):
+            xmin > self.x_right + self.x_pixel_size / 2
+            or xmax < self.x_left - self.x_pixel_size / 2
+            or ymin > self.y_top + self.y_pixel_size / 2
+            or ymax < self.y_bottom - self.x_pixel_size / 2
+        ):
             raise Nimrod.BboxRangeError
 
         # Limit bounds to within raster image
@@ -287,16 +312,22 @@ class Nimrod:
         # ('int' truncates floats towards zero)
         xMinPixelId = int((xmin - self.x_left) / self.x_pixel_size + 0.5)
         xMaxPixelId = int((xmax - self.x_left) / self.x_pixel_size + 0.5)
-        
-        # For y (northings), note the first data row stored is most north 
+
+        # For y (northings), note the first data row stored is most north
         yMinPixelId = int((self.y_top - ymax) / self.y_pixel_size + 0.5)
         yMaxPixelId = int((self.y_top - ymin) / self.y_pixel_size + 0.5)
-          
+
         bbox_data = []
         for i in range(yMinPixelId, yMaxPixelId + 1):
-            bbox_data.extend(self.data[i * self.ncols + xMinPixelId:
-                                       i * self.ncols + xMaxPixelId + 1])
-            
+            bbox_data.extend(
+                self.data[
+                    i * self.ncols
+                    + xMinPixelId : i * self.ncols
+                    + xMaxPixelId
+                    + 1
+                ]
+            )
+
         # Update object where necessary
         self.data = bbox_data
         self.x_right = self.x_left + xMaxPixelId * self.x_pixel_size
@@ -310,69 +341,87 @@ class Nimrod:
         self.hdr_element[34] = self.y_top
         self.hdr_element[36] = self.x_left
 
-
-    def extract_asc (self, outfile):
+    def extract_asc(self, outfile):
         """
         Write raster data to an ESRI ASCII (.asc) format file.
-        
+
         Args:
             outfile: file object opened for writing text
         """
-        
+
         # As ESRI ASCII format only supports square pixels, warn if not so
         if self.x_pixel_size != self.y_pixel_size:
-            print ("Warning: x_pixel_size(%d) != y_pixel_size(%d)"
-                   % (self.x_pixel_size, self.y_pixel_size))
-                
+            print(
+                "Warning: x_pixel_size(%d) != y_pixel_size(%d)"
+                % (self.x_pixel_size, self.y_pixel_size)
+            )
+
         # Write header to output file. Note that data is valid at the centre
-        # of each pixel so "xllcenter" rather than "xllcorner" must be used  
+        # of each pixel so "xllcenter" rather than "xllcorner" must be used
         outfile.write("ncols          %d\n" % self.ncols)
         outfile.write("nrows          %d\n" % self.nrows)
         outfile.write("xllcenter     %d\n" % self.x_left)
         outfile.write("yllcenter     %d\n" % self.y_bottom)
         outfile.write("cellsize       %.1f\n" % self.y_pixel_size)
         outfile.write("nodata_value  %.1f\n" % self.hdr_element[38])
-    
-        # Write raster data to output file    
+
+        # Write raster data to output file
         for i in range(self.nrows):
             for j in range(self.ncols - 1):
-                outfile.write("%d " % self.data[i*self.ncols + j])
-            outfile.write("%d\n" % self.data[i*self.ncols + self.ncols - 1])
+                outfile.write("%d " % self.data[i * self.ncols + j])
+            outfile.write("%d\n" % self.data[i * self.ncols + self.ncols - 1])
         outfile.close()
 
 
-#-------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 # Handle if called as a command line script
 # (And as an example of how to invoke class methods from an importing module)
-#-------------------------------------------------------------------------------
-import argparse
+# ------------------------------------------------------------------------------
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="Extract information and data from a NIMROD format file",
         epilog="""Note that any bounding box must be specified in the same
                   units and projection as the input file. The bounding box
                   does not need to be contained by the input raster but
-                  must intersect it.""")
-    parser.add_argument("-q", "--query", action="store_true",
-                        help="Display metadata")
-    parser.add_argument("-x", "--extract", action="store_true",
-                        help="Extract raster file in ASC format")
-    parser.add_argument('infile', nargs='?', type=argparse.FileType('rb'),
-                        default=sys.stdin,
-                        help="(Uncompressed) NIMROD input filename")
-    parser.add_argument('outfile', nargs='?', type=argparse.FileType('w'),
-                        default=sys.stdout,
-                        help="Output raster filename (*.asc)")
-    parser.add_argument("-bbox", type=float, nargs=4,
-                        metavar=('XMIN', 'XMAX', 'YMIN', 'YMAX'),
-                        help="Bounding box to clip raster data to")
+                  must intersect it.""",
+    )
+    parser.add_argument(
+        "-q", "--query", action="store_true", help="Display metadata"
+    )
+    parser.add_argument(
+        "-x",
+        "--extract",
+        action="store_true",
+        help="Extract raster file in ASC format",
+    )
+    parser.add_argument(
+        "infile",
+        nargs="?",
+        type=argparse.FileType("rb"),
+        default=sys.stdin,
+        help="(Uncompressed) NIMROD input filename",
+    )
+    parser.add_argument(
+        "outfile",
+        nargs="?",
+        type=argparse.FileType("w"),
+        default=sys.stdout,
+        help="Output raster filename (*.asc)",
+    )
+    parser.add_argument(
+        "-bbox",
+        type=float,
+        nargs=4,
+        metavar=("XMIN", "XMAX", "YMIN", "YMAX"),
+        help="Bounding box to clip raster data to",
+    )
     args = parser.parse_args()
 
     if not args.query and not args.extract:
         parser.print_help()
         sys.exit(1)
-        
+
     # Initialise data object by reading NIMROD file
     # (Only trap record length exception as others self-explanatory)
     try:
@@ -380,10 +429,9 @@ if __name__ == '__main__':
     except Nimrod.RecordLenError as error:
         sys.stderr.write("ERROR: %s\n" % error.message)
         sys.exit(1)
-          
+
     if args.bbox:
-        sys.stderr.write(
-            "Trimming NIMROD raster to bounding box...\n")
+        sys.stderr.write("Trimming NIMROD raster to bounding box...\n")
         try:
             rainfall_data.apply_bbox(*args.bbox)
         except Nimrod.BboxRangeError:
@@ -394,13 +442,15 @@ if __name__ == '__main__':
     # size of resulting image
     if args.query:
         rainfall_data.query()
-        
+
     if args.extract:
-        sys.stderr.write(
-            "Extracting NIMROD raster to ASC file...\n")
+        sys.stderr.write("Extracting NIMROD raster to ASC file...\n")
         sys.stderr.write(
             "  Outputting data array (%d rows x %d cols = %d pixels)\n"
-            % (rainfall_data.nrows, rainfall_data.ncols,
-               rainfall_data.nrows * rainfall_data.ncols))
+            % (
+                rainfall_data.nrows,
+                rainfall_data.ncols,
+                rainfall_data.nrows * rainfall_data.ncols,
+            )
+        )
         rainfall_data.extract_asc(args.outfile)
-    


### PR DESCRIPTION
Python 2 has been sunsetted, but this script is still of great use to members of the
research community, myself included.

I've taken the liberty of making the minor changes necessary to bring the script up to
compatability with Python 3 and its standard library. The script has also been formatted
to be approximately PEP-compliant through the use of linters like Black.

The changes have been tested on a number of NIMROD files over 2020 and 2021, using
Python 3.8 on macOS.

I hope these changes are welcome, and thank you for providing the original script.
